### PR TITLE
fix: (macos) use objc to get correct app name

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -156,6 +156,6 @@ pub async fn get_app_runtime_info(
 }
 
 #[tauri::command]
-pub async fn get_installed_apps(app_handle: tauri::AppHandle) -> Vec<String> {
-    util::get_installed_apps(&app_handle)
+pub async fn get_installed_apps() -> Vec<String> {
+    util::get_installed_apps().await
 }

--- a/src-tauri/src/core/util/macos.rs
+++ b/src-tauri/src/core/util/macos.rs
@@ -1,7 +1,6 @@
 use objc::runtime::Object;
 use objc::{class, msg_send, sel, sel_impl};
 use objc_foundation::{INSString, NSString};
-use std::process::Command;
 
 pub fn check_whitelist(whitelist_apps: &Vec<String>) -> bool {
     #[cfg(target_os = "macos")]
@@ -11,12 +10,10 @@ pub fn check_whitelist(whitelist_apps: &Vec<String>) -> bool {
             if !workspace.is_null() {
                 let app: *mut Object = msg_send![workspace, frontmostApplication];
                 if !app.is_null() {
-                    let name: *mut Object = msg_send![app, localizedName];
-                    if !name.is_null() {
-                        let ns_string: &NSString = unsafe { &*(name as *const NSString) };
-                        let app_name = ns_string.as_str().to_string();
-
-                        return whitelist_apps.contains(&app_name);
+                    let url: *mut Object = msg_send![app, bundleURL];
+                    let name = get_mditem_display_name_by_url(url);
+                    if let Some(name) = name {
+                        return whitelist_apps.contains(&name.trim_end_matches(".app").to_string());
                     }
                 }
             }
@@ -25,35 +22,68 @@ pub fn check_whitelist(whitelist_apps: &Vec<String>) -> bool {
     false
 }
 
-pub fn get_local_installed_apps(app_handle: &tauri::AppHandle) -> Vec<String> {
-    let self_name = app_handle.package_info().name.clone();
+pub async fn get_local_installed_apps() -> Vec<String> {
+    let mut files = tokio::fs::read_dir("/Applications")
+        .await
+        .expect("failed to read directory");
 
-    let output = Command::new("ls")
-        .arg("/Applications")
-        .output()
-        .expect("failed to execute command");
+    let self_path = get_self_bundle_path();
 
-    String::from_utf8_lossy(&output.stdout)
-        .split('\n')
-        .filter(|app| app.ends_with(".app"))
-        .filter(|app| !app.starts_with(&format!("{}.app", self_name))) // 过滤掉本应用
-        .filter_map(|app| {
-            let path = format!("/Applications/{}", app);
-            let output = Command::new("mdls")
-                .args(["-name", "kMDItemDisplayName", "-raw", &path])
-                .output()
-                .ok()?;
+    let mut display_names = vec![];
+    while let Ok(Some(entry)) = files.next_entry().await {
+        let path = entry.path();
+        let app = path
+            .file_name()
+            .expect("failed to get file name")
+            .to_string_lossy();
+        if !app.ends_with(".app") {
+            continue;
+        }
 
-            let display_name = String::from_utf8_lossy(&output.stdout)
-                .trim()
-                .trim_end_matches(".app")
-                .to_string();
+        let path_str = path.to_string_lossy();
+        if path_str == self_path {
+            continue;
+        }
 
-            if !display_name.is_empty() {
-                Some(display_name)
-            } else {
-                Some(app.trim_end_matches(".app").to_string())
-            }
-        })
-        .collect()
+        if let Some(display_name) = get_mditem_display_name_by_path(&path_str) {
+            display_names.push(display_name.trim_end_matches(".app").to_string());
+        } else {
+            display_names.push(app.trim_end_matches(".app").to_string());
+        }
+    }
+
+    display_names.sort();
+    display_names
+}
+
+pub fn get_mditem_display_name_by_path(path: &str) -> Option<String> {
+    unsafe {
+        let path = NSString::from_str(path);
+        let url: *mut Object = msg_send![class!(NSURL), fileURLWithPath: path];
+        get_mditem_display_name_by_url(url)
+    }
+}
+
+pub fn get_self_bundle_path() -> String {
+    unsafe {
+        let bundle: *mut Object = msg_send![class!(NSBundle), mainBundle];
+        let url: *mut Object = msg_send![bundle, bundlePath];
+        let ns_string: &NSString = &*(url as *const NSString);
+        ns_string.as_str().to_string()
+    }
+}
+
+pub unsafe fn get_mditem_display_name_by_url(url: *const Object) -> Option<String> {
+    let cls = class!(NSMetadataItem);
+    let alloc: *mut Object = msg_send![cls, alloc];
+    let item: *mut Object = msg_send![alloc, initWithURL:url];
+    let name: *mut Object =
+        msg_send![item, valueForAttribute: NSString::from_str("kMDItemDisplayName")];
+
+    if !name.is_null() {
+        let ns_string: &NSString = &*(name as *const NSString);
+        return Some(ns_string.as_str().to_string());
+    }
+
+    None
 }

--- a/src-tauri/src/core/util/mod.rs
+++ b/src-tauri/src/core/util/mod.rs
@@ -18,10 +18,10 @@ pub fn is_frontapp_in_whitelist(whitelist_apps: &Vec<String>) -> bool {
     false
 }
 
-pub fn get_installed_apps(app_handle: &tauri::AppHandle) -> Vec<String> {
+pub async fn get_installed_apps() -> Vec<String> {
     #[cfg(target_os = "macos")]
     {
-        return get_local_installed_apps(&app_handle);
+        return get_local_installed_apps().await;
     }
 
     vec![]


### PR DESCRIPTION
使用命令行获取的 `kMDItemDisplayName` 与 `app.localizedName` 不一样，比如vscode的`kMDItemDisplayName`为`Visual Studio Code`，而`app.localizedName`为`Code`

测试代码(因为需要vscode才能运行，没有并入)：

```rust

#[cfg(test)]
mod tests {

    use super::*;

    #[tokio::test]
    async fn test_workspace() {
        let apps = get_local_installed_apps().await;
        assert!(apps.contains(&"Visual Studio Code".to_string()));
    }

    #[test]
    fn test_whitelist() {
        let apps = vec!["Visual Studio Code".to_string()];

        let is_whitelist = check_whitelist(&apps);
        assert!(is_whitelist);
    }

    #[test]
    fn test_bundle() {
        let bundle = get_self_bundle_path();
        println!("bundle: {}", bundle);
    }
}

```